### PR TITLE
resolves #13, stripe pattern fill on map

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -85,5 +85,199 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <!-- Leaflet map SVG patterns -->
+    <svg id="map-pattern-fills" width="0" height="0" aria-hidden="true">
+      <defs>
+        <pattern
+          id="pattern-few-protections"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <path
+            stroke="#5e5e5e"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+        <pattern
+          id="pattern-some-protections"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <path
+            stroke="#bdbdbd"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+        <pattern
+          id="pattern-many-protections"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <path
+            stroke="#ffffff"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+
+        <!-- city protections have a slightly modified pattern to better differentiate them -->
+        <pattern
+          id="pattern-few-protections--city-level"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(135)"
+        >
+          <path
+            stroke="#5e5e5e"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+        <pattern
+          id="pattern-some-protections--city-level"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(135)"
+        >
+          <path
+            stroke="#bdbdbd"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+        <pattern
+          id="pattern-many-protections--city-level"
+          x="0"
+          y="0"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternContentUnits="userSpaceOnUse"
+          patternTransform="rotate(135)"
+        >
+          <path
+            stroke="#ffffff"
+            stroke-opacity="1"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 2 H 8"
+          ></path>
+          <path
+            stroke="#ffffff"
+            stroke-opacity="0"
+            stroke-width="4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            pointer-events="none"
+            d="M0 6 H 8"
+          ></path>
+        </pattern>
+      </defs>
+    </svg>
+
   </body>
 </html>

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -8,7 +8,7 @@
   right: 0;
   z-index: 0;
 
-  .leaflet-pane.leaflet-overlay-pane svg {
+  .leaflet-pane svg {
     path {
       @include use-svg-pattern("few");
       @include use-svg-pattern("few", true);


### PR DESCRIPTION
Might not be the most elegant way to do this, but it works. Only made changes to two files:
- added the svg that used to live in `index.html` back in to`public/index.html`
- removed the targeting class `.leaflet-overlay-pane` from `_map.scss` for the svg styling because the panes now have 
specific class names (i.e. `.leaflet-states-pane`)

I spent some time trying to have the svg exist in its own file but couldn't figure out how to reference it correctly in the stylesheet. There are packages like [this one](https://github.com/teastman/Leaflet.pattern) that would allow for specifying the pattern when the map is initialized as opposed to by targeting the class. I'm not sure if that would be faster or better.