### PR TITLE
Resolves #14, slightly rewrites i8n tests to report each language pass/fail

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -2,7 +2,7 @@
   "page-title": "Globale Karte: Das Recht auf Wohnen in Zeiten der Pandemie",
   "modal": {
     "title": "Globale Karte: Das Recht auf Wohnen in Zeiten der Pandemie",
-    "warning": "Bei dieser Karte handelt es sich um ein Notfallprojekt zur Darstellung der globalen Maßnahmen zum Schutz von Mieter*innen und Aktionen für das Recht auf Wohnen in Zeiten von COVID-19. Wir wissen, dass Verdrängung trotz Schutzmaßnahmen stattfindet und dass viele Schutzmaßnahmen schon wieder ausgelaufen sind. Bitte füllt <a href='https://airtable.com/shrHbY2q4ZmFtkB9d' target='_blank rel='noreferrer noopener'>unseren Fragebogen</a> zur Karte aus, um Zwangsräumungen oder Schikanierung durch Vermieter*innen in eurer Gegend zu dokumentieren. Ihr findet auf der Karte auch Informationen zu Rechtshilfe und gemeinnützigen Organisationen in eurer Gegend.",
+    "warning": "Bei dieser Karte handelt es sich um ein Notfallprojekt zur Darstellung der globalen Maßnahmen zum Schutz von Mieter*innen und Aktionen für das Recht auf Wohnen in Zeiten von COVID-19. Wir wissen, dass Verdrängung trotz Schutzmaßnahmen stattfindet und dass viele Schutzmaßnahmen schon wieder ausgelaufen sind. <a class='hlt-yellow' href='https://airtable.com/shrI5HxbTqEFbk89Y' target='_blank' rel='noreferrer noopener'>Bitte füllt unseren Fragebogen zur Karte aus, um Zwangsräumungen oder Schikanierung durch Vermieter*innen in eurer Gegend zu dokumentieren</a>. Ihr findet auf der Karte auch Informationen zu Rechtshilfe und gemeinnützigen Organisationen in eurer Gegend.",
     "content": {
       "paragraph-1": "Die Karte ist ein Projekt des <a href='https://antievictionmap.com/' target='_blank rel='noreferrer noopener'>Anti-Eviction Mapping Project</a>, einem Daten-Visualisierungs-, Datenanalyse- und Storytelling-Kollektiv mit Sektionen vor allem in San Francisco, Los Angeles und New York sowie Kooperationspartner*innen weltweit. Anti-Eviction Mapping Project sammelt seid Jahrzehnten Daten unter Verwendung freier und quelloffener Technologien, um soziale Bewegungen, gemeinnützige Organisationen sowie Forscher*innen zu unterstützen, die sich für Wohnungsgerechtigkeit einsetzen. Die hier dargestellten Daten stammen aus einer Vielzahl von Quellen und sind keineswegs perfekt oder vollständig.",
       "paragraph-2": "Trotz des Bewusstseins darüber, dass heutige staatlich-administrative Grenzen weltweit oft das historische Resultat von gewaltsamer Kolonisierung sind, bildet die Karte auch diese Grenzen ab, um aktuelle Schutzmaßnahmen zu visualisieren, die von, aus Kolonalisierung entstandnen, staatlichen Verwaltungen umgesetzt werden. Weitere Informationen zur Datenerhebung, zur Weitergabe und zum Datenschutz findet Ihr <a href='https://antievictionmap.com/data-use-agreement' target='_blank rel='noreferrer noopener'>hier</a>.",
@@ -18,7 +18,7 @@
     "aemp-name": "The Anti-Eviction Mapping Project",
     "about-protections": "Gesetze und Maßnahmen zum Schutz von Mieter*innen",
     "about-description": "Orte, an denen Maßnahmen zum Schutz von Mieter*innen während der Coronavirus-Krise verabschiedet wurden (oder in Vorbereitung sind).",
-    "legislation-form-intl": "Teile Informationen über Maßnahmen zum Schutz von Mieter*innen.",
+    "legislation-form-intl": "Räumungen und Räumungsmoratorien.",
     "housing-action-title": "Aktionen für das Recht auf Wohnen",
     "housing-action-description": "Wo finden oder fanden<strong class='color-rent-strike'>Aktionen für das Recht auf Wohnen</strong> statt.",
     "housing-action-form": "Teile Informationen über Aktionen für das Recht auf Wohnen in deiner Stadt (z.B. Besetzungen, Mietstreiks, Verhandlungen um Mietminderung...)",
@@ -50,6 +50,7 @@
       "court-closure-end-label": "Ablaufdatum des rechtlichen Räumungsverbots:",
       "start-date-label": "Inkrafttreten der Maßnahme:",
       "end-date-label": "Ende:",
+      "eviction-status-label": "Räumungsstatus:",
       "summary-label": "Zusammenfassung der Maßnahme:",
       "link": "Für weitere Informationen klicke hier.",
       "resource-link": "Für weitere Materialien klicke hier."

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2,7 +2,7 @@
   "page-title": "COVID-19 Global Housing Protection Legislation and Housing Justice Action Map",
   "modal": {
     "title": "COVID-19 Global Housing Protection Legislation and Housing Justice Action Map",
-    "warning": "We know that evictions are happening despite protections, and that many protections have expired. Please fill out our survey on the map to add information about evictions where you live. You can also use the map to find legal aid and community organizers in your area. If you are experiencing eviction or landlord harassment, you can also fill out our <a href='https://airtable.com/shrHbY2q4ZmFtkB9d' target='_blank rel='noreferrer noopener'>survey here</a>.",
+    "warning": "We know that evictions are happening despite protections, and that many protections have expired. Please fill out our survey on the map to add information about evictions where you live. You can also use the map to find legal aid and community organizers in your area. <a class='hlt-yellow' href='https://airtable.com/shrI5HxbTqEFbk89Y' target='_blank' rel='noreferrer noopener'>If you are experiencing eviction, landlord harassment, or want to share your story, you can also fill out our survey here</a>.",
     "content": {
       "paragraph-1": "This map is an emergency response project to present COVID-19 global housing legislation and housing justice action information. It is by the Anti-Eviction Mapping Project, a data-visualization, data analysis, and storytelling collective with chapters primarily in San Francisco, Los Angeles, and New York as well as collaborators worldwide.",
       "paragraph-2": "The Anti-Eviction Mapping Project aggregates data using free and open-source technologies to support social movements, community organizations, and research groups working toward housing justice. Data is crowd-sourced and by no means perfectly or exhaustively. For more info. on our data collection, sharing, and privacy, see <a href='https://antievictionmap.com/data-use-agreement' target='_blank rel='noreferrer noopener'>here</a>.",
@@ -18,10 +18,10 @@
     "aemp-name": "The Anti-Eviction Mapping Project",
     "about-protections": "Housing Protection Legislation",
     "about-description": "Where officials have passed (or tenants are working to pass) housing protection legislation during the COVID-19 crisis.",
-    "legislation-form-intl": "Global Housing Protection Legislation.",
+    "legislation-form-intl": "Evictions and Eviction Moratoriums.",
     "housing-action-title": "Housing Justice Action",
     "housing-action-description": "Where <strong class='color-rent-strike'>housing justice actions</strong> are occurring or have occured.",
-    "housing-action-form": "Housing justice actions around the world.",
+    "housing-action-form": "Housing Justice Actions and Landlord Harassment.",
     "submit": "Submit data",
     "resources": {
       "title": "Resources",
@@ -50,6 +50,7 @@
       "court-closure-end-label": "Court Closures End Date:",
       "start-date-label": "Effective:",
       "end-date-label": "Ends:",
+      "eviction-status-label": "Eviction status:",
       "summary-label": "Policy Summary:",
       "info-link": "View more info.",
       "resource-link": "View associated resource."

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -2,7 +2,7 @@
   "page-title": "Protección de Emergencia Global para Inquilinos y movilización contra los desalojos durante la pandemia COVID-19",
   "modal": {
     "title": "Protección de Emergencia Global para Inquilinos y movilización contra los desalojos durante la pandemia COVID-19",
-    "warning": "Sabemos que se están produciendo desalojos a pesar de las protecciones, y que muchas protecciones han expirado.Por favor, rellene nuestro cuestionario en el mapa para añadir información sobre los desalojos en el lugar donde vive. También puede usar el mapa para encontrar ayuda legal y organizadores comunitarios en su área. Si está experimentando un desalojo o acoso por parte del propietario, también puede rellenar nuestro <a href='https://airtable.com/shrHbY2q4ZmFtkB9d' target='_blank rel='noreferrer noopener'>cuestionario aquí</a>.",
+    "warning": "Sabemos que se están produciendo desalojos a pesar de las protecciones, y que muchas protecciones han expirado.Por favor, rellene nuestro cuestionario en el mapa para añadir información sobre los desalojos en el lugar donde vive. También puede usar el mapa para encontrar ayuda legal y organizadores comunitarios en su área. <a class='hlt-yellow' href='https://airtable.com/shrI5HxbTqEFbk89Y' target='_blank' rel='noreferrer noopener'>Si está experimentando un desalojo o acoso por parte del propietario, o deseas compartir su historia, también puede rellenar nuestro cuestionario aquí</a>.",
     "content": {
       "paragraph-1": "Este mapa es un proyecto de respuesta de emergencia para presentar la legislación mundial sobre vivienda de COVID-19 y la información sobre la acción de la justicia en materia de vivienda. Es realizado por el Proyecto de Mapeo Antidesalojo, un colectivo de visualización de datos, análisis de datos y narración de historias de vida con capítulos principalmente en San Francisco, Los Ángeles y Nueva York, así como colaboradores en todo el mundo.",
       "paragraph-2": "El proyecto de cartografía contra el desalojo reúne datos utilizando tecnologías libres y de código abierto para apoyar a los movimientos sociales, las organizaciones comunitarias y los grupos de investigación que trabajan en pro de la justicia en materia de vivienda. Los datos son de origen colectivo y de ninguna manera son perfectos o exhaustivos. Para obtener más información sobre la copilación, el intercambio y la privacidad de los datos, vea <a href='https://antievictionmap.com/data-use-agreement' target='_blank rel='noreferrer noopener'>aquí</a>.",
@@ -18,7 +18,7 @@
     "aemp-name": "Anti-Eviction Mapping Project",
     "about-protections": "Legislación de protección",
     "about-description": "En el contexto de la pandemia, estamos mapeando en qué ciudades, condados, estados los gobiernos han aprobado (o donde los inquilinos trabajan para lograr aprobar) legislación de emergencia que suspenda desalojos o asegure la permanencia de los inquilinos en sus hogares.",
-    "legislation-form-intl": "Envie información sobre legislación de protección global.",
+    "legislation-form-intl": "Desalojos y Moratorias de Desalojos.",
     "housing-action-title": "Movilización para la defensa de la vivienda",
     "housing-action-description": "Donde <strong class='color-rent-strike'>acciones para la justicia</strong> están ocurriendo o han ocurrido.",
     "housing-action-form": "Complete para presentar la información sobre: Organización, resistencia y ayuda mutua en forma de huelgas de alquiler, recuperación de viviendas, ocupaciones y más. También llene si busca las redes de solidaridad y recursos para ayudar a cancelar el alquiler.",
@@ -50,6 +50,7 @@
       "court-closure-end-label": "Fecha de cierre del tribunal:",
       "start-date-label": "Efectivo",
       "end-date-label": "Finaliza:",
+      "eviction-status-label": "Estado de desalojos:",
       "summary-label": "Resumen de la política",
       "info-link": "Ver más información",
       "resource-link": "Ver más recursos asociados."

--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -55,6 +55,7 @@
       "court-closure-end-label": "Data di cessazione dell'impedimento legale allo sfratto:",
       "start-date-label": "Inizio effettivo:",
       "end-date-label": "Fine:",
+      "eviction-status-label": "Stato degli sfratti:",
       "summary-label": "Sintesi della misura:",
       "info-link": "Accedi a maggiori informazioni.",
       "resource-link": "Accedi a maggiori informazioni."

--- a/src/locale/locale.test.js
+++ b/src/locale/locale.test.js
@@ -19,7 +19,6 @@ const keyify = (obj, prefix = '') =>
   }, []);
 
 describe('Validate translations', () => {
-  test('has the same keys in every file', () => {
     const enKeys = keyify(en);
     // Get the list of keys for each localisation file
     const translationKeys = Object.values(translations).map(translation => {
@@ -28,11 +27,11 @@ describe('Validate translations', () => {
 
     // For all translations
     translationKeys.forEach((translation, index) => {
-      // Check against the english file
-      expect(
-        enKeys.sort(),
-        `Comparing en with ${Object.keys(translations)[index]}`
-      ).toEqual(translation.sort());
-    });
+      test('"' + Object.keys(translations)[index] + '" has the same keys as "en"', () => {
+        // Check against the english file
+        expect(
+          enKeys.sort()
+        ).toEqual(translation.sort());
+      });
   });
 });

--- a/src/locale/pt-BR.json
+++ b/src/locale/pt-BR.json
@@ -2,7 +2,7 @@
   "page-title": "COVID-19: Legislação de Proteção Global e Mobilização pelo Acesso à Moradia",
   "modal": {
     "title": "COVID-19: Legislação de Proteção Global e Mobilização pelo Acesso à Moradia",
-    "warning": "Nós sabemos que os despejos estão acontecendo apesar de existerem recursos legais de proteção. Por favor, preenche este questionário para ajudar a mapear e coletar informações sobre os despejos onde você mora. Você pode usar este mapa para encontrar ajuda jurídica e grupos de apoio na sua região. Se você está sendo alvo de ameaças de despejo, <a href='https://airtable.com/shrHbY2q4ZmFtkB9d' target='_blank rel='noreferrer noopener'>preencha este questionário aqui</a>.",
+    "warning": "Nós sabemos que os despejos estão acontecendo apesar de existerem recursos legais de proteção. Por favor, preenche este questionário para ajudar a mapear e coletar informações sobre os despejos onde você mora. Você pode usar este mapa para encontrar ajuda jurídica e grupos de apoio na sua região.<a class='hlt-yellow' href='https://airtable.com/shrI5HxbTqEFbk89Y' target='_blank' rel='noreferrer noopener'>Se você está sendo alvo de ameaças de despejo ou deseja contar sua história, preencha este questionário</a>.",
     "content": {
       "paragraph-1": "Este mapa é parte de uma resposta de emergência com o objetivo de compartilhar informações sobre legislação de proteção e ações de defesa da moradia durante a pandemia. Ele foi feito pelo Projeto de Mapeamento Contra os Despejos (AEMP), um coletivo de visualização, análise e narrativas de vida com colaboradores em várias partes do mundo.",
       "paragraph-2": "AEMP agrega data usando tecnologias livres e de código aberto para apoiar movimentos sociais e grupos de pesquisa para promover a justiça no acesso à moradia. Os dados são coletados de forma colaborativa e não é exaustivo ou perfeito. Para saber mais sobre a nossa política de compartilhamento e privacidade dos dados, <a href='https://antievictionmap.com/data-use-agreement' target='_blank rel='noreferrer noopener'>clique aqui</a>.",
@@ -50,6 +50,7 @@
       "court-closure-end-label": "Data do fim do impedimento legal de despejos:",
       "start-date-label": "Inicio efetivo:",
       "end-date-label": "Fim:",
+      "eviction-status-label": "Situação dos despejos:",
       "summary-label": "Resumo da política:",
       "info-link": "Acesse maiores informações.",
       "resource-link": "Acesse fontes associadas."


### PR DESCRIPTION
- Copied over all translation json files within `src/locale` from the original project repository so they should be up-to-date
- Slightly rewrote `src/locale/locale.test.js` so that each translation has its own test and the error reporting is more granular. Previously, I believe the test would stop running when it hit the first file with keys that didn't match the English version.

New test reporting:
<img width="564" alt="Screen Shot 2021-02-02 at 3 29 52 PM" src="https://user-images.githubusercontent.com/19356745/106678101-dd631c00-656e-11eb-8956-f891ec0d7dfc.png">

versus old test reporting:
<img width="562" alt="Screen Shot 2021-02-02 at 3 30 08 PM" src="https://user-images.githubusercontent.com/19356745/106678125-e94ede00-656e-11eb-985b-8e9524a2c2e3.png">