### PR TITLE
Style adjustments for search results (fixes #38)

### DIFF
--- a/src/styles/_search-bar.scss
+++ b/src/styles/_search-bar.scss
@@ -34,14 +34,15 @@
   width: 100%;
   height: 50%;
   background-color: white;
-  margin-top: 20px;
+  margin-top: 37px;
   padding: 0;
   cursor: pointer;
+  font-family: 'IBM Plex Mono', monospace;
 
   li {
-    padding: 2px;
+    padding: 6px 8px;
     list-style-type: none;
-    font-size: 1.1em;
+    font-size: 1.2em;
   }
 
   li:hover {


### PR DESCRIPTION
@brett-halperin here is the before and after. Thoughts?

Before:
<img width="604" alt="Screen Shot 2021-05-16 at 9 42 23 AM" src="https://user-images.githubusercontent.com/1253402/118410467-64cb2b80-b644-11eb-8bd4-441f0e916397.png">

After:
<img width="604" alt="Screen Shot 2021-05-16 at 9 41 50 AM" src="https://user-images.githubusercontent.com/1253402/118410472-6eed2a00-b644-11eb-9914-a48747093038.png">

