### PR TITLE
Add "Last updated" timestamp to InfoWindow - fixes #46

### DIFF
--- a/src/carto/queries.js
+++ b/src/carto/queries.js
@@ -16,7 +16,7 @@ SELECT
   municipality, state, country, range, has_expired_protections,
   policy_type, policy_summary, link, resource, the_geom,
   end_date_earliest, end_date_legist, end_date_rent_relief, end_date_court,
-  eviction_status
+  eviction_status, reviewed_date
 FROM ${cartoSheetSyncTable}
 WHERE the_geom is not null and admin_scale = 'City'
 ORDER BY range`;
@@ -28,7 +28,7 @@ SELECT
   m.range, m.has_expired_protections,
   m.end_date_earliest, m.end_date_legist,
   m.end_date_rent_relief, m.end_date_court,
-  m.eviction_status
+  m.eviction_status, m.reviewed_date
 FROM ${cartoCountiesTable} c
 JOIN ${cartoSheetSyncTable} m
 ON ST_Intersects(c.the_geom, m.the_geom)
@@ -44,7 +44,7 @@ SELECT
   m.link, m.resource, m.has_expired_protections,
   m.end_date_earliest, m.end_date_legist, 
   m.end_date_rent_relief, m.end_date_court,
-  m.eviction_status
+  m.eviction_status, m.reviewed_date
 FROM ${cartoStatesTable} s
 INNER JOIN ${cartoSheetSyncTable} m
   ON s.name = m.state
@@ -56,7 +56,8 @@ export const countriesCartoQuery = `
 SELECT
   c.the_geom, c.adm0_a3, c.name_en, m.range,
   m.policy_type, m.policy_summary, m.link, m.resource, 
-  m.has_expired_protections, m.end_date_earliest
+  m.has_expired_protections, m.end_date_earliest,
+  m.reviewed_date
 FROM ${cartoNationsTable} c
 INNER JOIN ${cartoSheetSyncTable} m
   ON c.adm0_a3 = m.iso

--- a/src/components/InfoWindow.js
+++ b/src/components/InfoWindow.js
@@ -28,6 +28,7 @@ export default props => {
     end,
     link,
     resource,
+    reviewed_date,
     // Action props
     action,
     actionStart,
@@ -226,6 +227,13 @@ export default props => {
                   {t('infowindow.policy.resource-link')}
                 </a>
               </p>
+            </
+            div>
+          )}
+          
+          {reviewed_date && (
+            <div>
+              <p className="infowindow-timestamp">Last Updated {reviewed_date}</p>
             </div>
           )}
         </>

--- a/src/styles/_map-infowindow.scss
+++ b/src/styles/_map-infowindow.scss
@@ -105,3 +105,9 @@
 .infowindow-link:visited > a {
   color: $link-visited;
 }
+
+.infowindow-timestamp {
+  font-size: 1.2rem;
+  font-style: italic;
+  color: $caption-color;
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -16,6 +16,7 @@ $policy-color-str-1: #5e5e5e;
 $policy-color-str-2: #bdbdbd;
 $policy-color-str-3: #fff;
 $link-visited: #797979;
+$caption-color: #6d7278;
 $font-color-black: #000;
 $highlight-color-yellow: #feff54;
 


### PR DESCRIPTION
Initial commit for this work. Some open questions on this:

1. What format should we display it as? We can format it on the front-end but seems our other dates are formatted on the backend? Thoughts @unixjazz @azadag?

Current implementation:

![image](https://user-images.githubusercontent.com/1253402/119285534-19da8680-bbf7-11eb-9ef8-7763f32c7fa5.png)

Other dates:

![image](https://user-images.githubusercontent.com/1253402/119285521-147d3c00-bbf7-11eb-89c3-89a6e809a8db.png)

2. Do we want this timestamp at the very bottom of the InfoWindow still or at the top? @brett-halperin, please confirm.

3. Do we want to localize "Last Updated" string? Thoughts @brett-halperin @erinmcel?


